### PR TITLE
fix file permissions with arbitrary uids for image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,9 @@ RUN apk add --no-cache bash
 # Make our shell script executable
 RUN chmod +x /app/build/env.sh
 
+# Make all files accessible such that the image supports arbitrary  user ids
+RUN chgrp -R 0 /app && \
+    chmod -R g=u /app
+
 # RUN echo -e window.__version="{\"version\":\""$VERSION"\"}" > /app/build/version.js
 CMD [ "/bin/bash", "-c", "/app/build/env.sh && yarn start:prod" ]


### PR DESCRIPTION
Make all files accessible to support arbitrary user ids running the docker image. There was an problem when trying to run this image on a openshift cluster which runs images in containers with arbitrary user ids (uid) by default.

This command showcases the current issue: `docker run -u112233 -p 8000:3000 -e HOST_URL=http://{ your machine IP }:8000 -e MILVUS_URL={your machine IP}:19530 milvusdb/milvus-insight:latest`

It fails with the following permission denied error: 
```
rm: can't remove './build/env-config.js': Permission denied
touch: ./build/env-config.js: Permission denied
/app/build/env.sh: line 8: ./build/env-config.js: Permission denied
/app/build/env.sh: line 26: ./build/env-config.js: Permission denied
/app/build/env.sh: line 26: ./build/env-config.js: Permission denied
/app/build/env.sh: line 29: ./build/env-config.js: Permission denied
```

The fix is to change the file permissions according to the docs here https://docs.openshift.com/container-platform/4.2/openshift_images/create-images.html (chapter "Support arbitrary user ids").